### PR TITLE
fix: windows crash when call Storage/Javascript

### DIFF
--- a/webview/storage_windows.go
+++ b/webview/storage_windows.go
@@ -17,11 +17,13 @@ type cookieManager struct {
 
 func newCookieManager(w *webview) *cookieManager {
 	r := &cookieManager{webview: w}
-	syscall.SyscallN(
-		r.webview.driver.webview22.VTBL.CookieManager,
-		uintptr(unsafe.Pointer(r.webview.driver.webview22)),
-		uintptr(unsafe.Pointer(&r._ICoreWebView2CookieManager)),
-	)
+	w.scheduler.MustRun(func() {
+		syscall.SyscallN(
+			r.webview.driver.webview22.VTBL.CookieManager,
+			uintptr(unsafe.Pointer(r.webview.driver.webview22)),
+			uintptr(unsafe.Pointer(&r._ICoreWebView2CookieManager)),
+		)
+	})
 	return r
 }
 

--- a/webview/webview_windows.go
+++ b/webview/webview_windows.go
@@ -92,8 +92,6 @@ func (r *driver) attach(w *webview) error {
 				syscall.SyscallN(r.webview2.VTBL.AddSourceChanged, uintptr(unsafe.Pointer(r.webview2)), uintptr(unsafe.Pointer(r.callbackLoad)))
 				syscall.SyscallN(r.webview2.VTBL.AddDocumentTitleChanged, uintptr(unsafe.Pointer(r.webview2)), uintptr(unsafe.Pointer(r.callbackTitle)))
 
-				w.javascriptManager = newJavascriptManager(w)
-				w.dataManager = newDataManager(w)
 				atomic.AddUint32(&r.active, 1)
 
 				return 0
@@ -129,6 +127,9 @@ func (r *driver) attach(w *webview) error {
 		}
 		w.scheduler.SetRunner(r.config.RunOnMain)
 	}()
+
+	w.javascriptManager = newJavascriptManager(w)
+	w.dataManager = newDataManager(w)
 
 	return nil
 }


### PR DESCRIPTION
Previously, it was possible to call such functions before the WebView is
read to receive those commands. Now, it's will be queue until the
WebView is initialized.